### PR TITLE
feat: Add Reply Macros header for NICK and USER commands only

### DIFF
--- a/inc/ReplyMacros.hpp
+++ b/inc/ReplyMacros.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+//Replys
+#define RPL_WELCOME(NICK, USER, HOST) (std::string("001") + " Welcome to the Internet Relay Network " + NICK + "!" + USER + "@" + HOST + "\r\n")
+#define RPL_TOPIC(CHANNEL, TOPIC) (std::string("332") + " " + CHANNEL + " :" + TOPIC)
+
+//Errors
+#define ERR_NONICKNAMEGIVEN (std::string("431") + " :No nickname given")
+#define ERR_ERRONEUSNICKNAME(NICK) (std::string("432") + " " + NICK + " :Erroneous nickname")
+#define ERR_NICKNAMEINUSE(NICK) (std::string("433") + " " + NICK + " :Nickname is already in use")
+#define ERR_NICKCOLLISION(NICK, USER, HOST) (std::string("436") + " " + NICK + " :Nickname collision KILL from " + USER + "@" + HOST)
+#define ERR_UNAVAILRESOURCE(NAME, TYPE) (std::string("437") + " " + NAME + " :" + TYPE + " is temporarily unavailable") //can be used for both nick and channel
+#define ERR_NEEDMOREPARAMS(COMMAND) (std::string("461") + " " + COMMAND + " :Not enough parameters")
+#define ERR_ALREDYREGISTRED (std::string("462") + " :Unauthorized command (already registered)")
+#define ERR_RESTRICTED (std::string("484") + " :Your connection is restricted!")


### PR DESCRIPTION
Reply Macro 정의를 모아두는 헤더 파일을 추가했습니다.
현재 NICK 과 USER 명령어와 관련된 Reply 와 Error 만 정의되어 있고,
이후 필요한 reply 는 기존 형태를 참고해서 추가하시면 됩니다.