### PR TITLE
fix: 메세지 객체 생성 시 parameter split 기능 수정

### DIFF
--- a/inc/ReplyMacros.hpp
+++ b/inc/ReplyMacros.hpp
@@ -1,26 +1,26 @@
 #pragma once
 
 //Replys
-#define RPL_WELCOME(NICK, USER, HOST) 		(std::string("001") + " Welcome to the Internet Relay Network " + NICK + "!" + USER + "@" + HOST + "\r\n")
-#define RPL_TOPIC(CHANNEL, TOPIC) 			(std::string("332") + " " + CHANNEL + " :" + TOPIC + "\r\n")
+#define RPL_WELCOME(NICK, USER, HOST) 		(std::string("001 ") + NICK + " Welcome to the Internet Relay Network " + NICK + "!" + USER + "@" + HOST + "\r\n")
+#define RPL_TOPIC(CHANNEL, TOPIC) 			(std::string("332 ") + CHANNEL + " :" + TOPIC + "\r\n")
 
 //Errors
 #define ERR_NOSUCHNICK(NICK)				(std::string("401 ") + NICK + " :No such nick\r\n")
-#define ERR_NOSUCHCHANNEL(CHANNEL)	(std::string("403 ") + (CHANNEL) + " :No such channel\r\n")
+#define ERR_NOSUCHCHANNEL(CHANNEL)			(std::string("403 ") + (CHANNEL) + " :No such channel\r\n")
 #define ERR_CANNOTSENDTOCHAN(CHAN)			(std::string("404 ") + CHAN + " :Cannot send to channel\r\n")
-#define ERR_TOOMANYCHANNELS(CHANNEL)	(std::string("405 ") + (CHANNEL) + " :You have joined too many channels\r\n")
+#define ERR_TOOMANYCHANNELS(CHANNEL)		(std::string("405 ") + (CHANNEL) + " :You have joined too many channels\r\n")
 #define ERR_NORECIPIENT(COMMAND)			(std::string("411 ") + ":No recipient given " + COMMAND + "\r\n")
 //TODO : 닉, 서버 분기에 따른 매크로 분할
 #define ERR_NOTEXTTOSEN						(std::string("412 :No text to send\r\n"))
-#define ERR_NONICKNAMEGIVEN (std::string("431") + " :No nickname given\r\n")
-#define ERR_ERRONEUSNICKNAME(NICK)			(std::string("432") + " " + NICK + " :Erroneous nickname\r\n")
-#define ERR_NICKNAMEINUSE(NICK)				(std::string("433") + " " + NICK + " :Nickname is already in use\r\n")
-#define ERR_NICKCOLLISION(NICK, USER, HOST) (std::string("436") + " " + NICK + " :Nickname collision KILL from " + USER + "@" + HOST + "\r\n")
-#define ERR_UNAVAILRESOURCE(NAME, TYPE) 	(std::string("437") + " " + NAME + " :" + TYPE + " is temporarily unavailable\r\n") //can be used for both nick and channel
-#define ERR_NEEDMOREPARAMS(COMMAND) 		(std::string("461") + " " + COMMAND + " :Not enough parameters\r\n")
+#define ERR_NONICKNAMEGIVEN 				(std::string("431") + " :No nickname given\r\n")
+#define ERR_ERRONEUSNICKNAME(NICK)			(std::string("432 ") + NICK + " :Erroneous nickname\r\n")
+#define ERR_NICKNAMEINUSE(NICK)				(std::string("433 ") + NICK + " :Nickname is already in use\r\n")
+#define ERR_NICKCOLLISION(NICK, USER, HOST) (std::string("436 ") + NICK + " :Nickname collision KILL from " + USER + "@" + HOST + "\r\n")
+#define ERR_UNAVAILRESOURCE(NAME, TYPE) 	(std::string("437 ") + NAME + " :" + TYPE + " is temporarily unavailable\r\n") //can be used for both nick and channel
+#define ERR_NEEDMOREPARAMS(COMMAND) 		(std::string("461 ") + COMMAND + " :Not enough parameters\r\n")
 #define ERR_ALREADYREGISTRED				(std::string("462 :Unauthorized command (already registered)\r\n"))
-#define ERR_CHANNELISFULL(CHANNEL)	(std::string("471 ") + (CHANNEL) + " :Cannot join channel (+i)\r\n")
-#define ERR_INVITEONLYCHAN(CHANNEL) (std::string("473 ") + (CHANNEL) + " :Cannot join channel (+i)\r\n")
-#define ERR_BANNEDFROMCHAN(CHANNEL)	(std::string("474 ") + (CHANNEL) + " :Cannot join channel (+b)\r\n")
-#define ERR_BADCHANNELKEY(CHANNEL) 			(std::string("475") + " " + CHANNEL + " :Cannot join channel (+k)\r\n")
+#define ERR_CHANNELISFULL(CHANNEL)			(std::string("471 ") + (CHANNEL) + " :Cannot join channel (+i)\r\n")
+#define ERR_INVITEONLYCHAN(CHANNEL) 		(std::string("473 ") + (CHANNEL) + " :Cannot join channel (+i)\r\n")
+#define ERR_BANNEDFROMCHAN(CHANNEL)			(std::string("474 ") + (CHANNEL) + " :Cannot join channel (+b)\r\n")
+#define ERR_BADCHANNELKEY(CHANNEL) 			(std::string("475 ") + CHANNEL + " :Cannot join channel (+k)\r\n")
 #define ERR_RESTRICTED						(std::string("484 :Your connection is restricted!\r\n"))

--- a/inc/message/AMessage.hpp
+++ b/inc/message/AMessage.hpp
@@ -8,11 +8,12 @@ class AMessage
 {
 	public:
 		static AMessage*	GetMessageObject(Client* origin, const std::string& msg);
-		const std::string&	GetCommand() const;
 		const std::string&	GetPrefix() const;
+		const std::string&	GetMessagePrefix() const;
+		const std::string&	GetCommand() const;
 		int					GetParamCount() const;
 		void				ReplyToOrigin(const std::string& replymsg);
-		void				ParseMessage(const std::string& msg);
+		void				ParseMessage();
 		virtual void		ExecuteCommand() = 0;
 		virtual 			~AMessage();
 
@@ -25,11 +26,12 @@ class AMessage
 
 	protected:
 		Client*		mOrigin;
-		std::string	mCommand;
 		std::string mPrefix;
-		std::string mBuff; //compile error purpose, to be removed
-		std::string	mBuffArray[17];
+		std::string	mMessagePrefix;
+		std::string	mCommand;
+		std::string	mParamArray[15];
 		int			mParamCount;
+		std::string mBuff;
 };
 
 #include "Client.hpp"

--- a/src/message/Nick.cpp
+++ b/src/message/Nick.cpp
@@ -5,13 +5,10 @@
 #include "Nick.hpp"
 
 Nick::Nick(Client* origin, const std::string msg) :
-AMessage(origin, "Nick", msg)
+AMessage(origin, "NICK", msg)
 {
-	int	index = 0;
-	while (mBuffArray[index] != "NICK" && index < mParamCount)
-		++index;
-	if (++index < mParamCount)
-		mNick =	mBuffArray[index];
+	if (mParamCount)
+		mNick =	mParamArray[0];
 }
 
 void	Nick::ExecuteCommand()

--- a/src/message/User.cpp
+++ b/src/message/User.cpp
@@ -2,28 +2,24 @@
 #include "message/User.hpp"
 
 User::User(Client* origin, const std::string msg) :
-AMessage(origin, "User", msg)
+AMessage(origin, "USER", msg)
 {
-	int	index = 0;
-	while (mBuffArray[index] != "USER" && index < mParamCount)
-		++index;
-
-	switch (mParamCount - index)
+	switch (mParamCount)
 	{
-		case 5:
-			mRealName = mBuffArray[index + 4];
-			//FALLTHROUGH
 		case 4:
-			mServerName = mBuffArray[index + 3];
+			mRealName = mParamArray[3];
 			//FALLTHROUGH
 		case 3:
-			mHostName = mBuffArray[index + 2];
+			mServerName = mParamArray[2];
 			//FALLTHROUGH
 		case 2:
-			mUserName = mBuffArray[index + 1];
+			mHostName = mParamArray[1];
 			//FALLTHROUGH
+		case 1:
+			mUserName = mParamArray[0];
+			break ;
 		default:
-			;
+			break ;
 	}
 }
 


### PR DESCRIPTION
메세지 객체 생성 시 해당 메세지를 mBuff 에 먼저 저장 후
prefix, command, parameter 를구분하여 각각 따로 저장

parameter 의 경우 mParamArray 에 14개의 개수 제한과 1개의 tailer parameter 까지 총 15개 저장 가능 이후 의 parameter 들은 오류로 보고 무시
mParamCount 로 개수 기록

prefix 는 기존의 mPrefix 멤버 변수와의 혼란을 피하기 위해 mMessagePrefix 로 명명 command 는 기존과 마찬가지로 mCommand 에 저장 유지