### PR TITLE
fix: AMessage GetMessageObject func substr abort bug

### DIFF
--- a/src/message/AMessage.cpp
+++ b/src/message/AMessage.cpp
@@ -49,28 +49,25 @@ AMessage*	AMessage::GetMessageObject(Client* origin, const std::string& msg)
 		return NULL;
 	}
 
-	AMessage*	message;
 	switch (index)
 	{
 		case 0:
-			message = new Pass(origin, msg);
-			break;
+			return new Pass(origin, msg);
 		case 1:
-			message = new Nick(origin, msg);
+			return new Nick(origin, msg);
 			break ;
 		case 2:
-			message = new User(origin, msg);
+			return new User(origin, msg);
 			break ;
 		case 3:
-			message = new Privmsg(origin, msg);
+			return new Privmsg(origin, msg);
 			break ;
 		case 4:
-			message = new Join(origin, msg);
+			return new Join(origin, msg);
 			break ;
 		default:
-			message = new NoCommand(origin, msg);
+			return NULL;
 	}
-	return message;
 }
 
 const std::string& AMessage::GetPrefix() const


### PR DESCRIPTION
register 후 9자 보다 짧은 명령어가 없는 메세지가 들어올 경우 AMessage 생성자에서 parameter 를 파싱하는 과정에서 substr 길이 오류로 abort 가 나는 문제 해결

메세지 객체 생성 전에 명령어가 아닌 메세지가 올 경우 기존의 NoCommand 객체 생성이 아닌 바로 NULL return 을 해버림으로 위의 문제 발생 상황 자체를 제한 해서 문제 해결